### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We thank the following excellent open-source works:
 
 Here is the list of highly related concurrent works:
 
-[LLM4SVG](https://arxiv.org/abs/2412.11102): treats SVG corodinates as number strings and predicts decimal part for higher spatial accuracy.
+[LLM4SVG](https://arxiv.org/abs/2412.11102): treats SVG coordinates as number strings and predicts decimal part for higher spatial accuracy.
 
-[StarVector](https://starvector.github.io/): equips LLM with a image encoder for Image-to-SVG generation.
+[StarVector](https://starvector.github.io/): equips LLM with an image encoder for Image-to-SVG generation.
 


### PR DESCRIPTION
fix: correct typo "corodinates" → "coordinates" in acknowledgments 
 
fix: correct grammar "a image encoder" → "an image encoder" in